### PR TITLE
Changed default behaviour + Writing strings in HTML element

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Check out the [demo and full documentation](https://www.webcomponents.org/elemen
 -->
 
 ## TODO
-- [ ] make looping the default behaviour
+- [x] make looping & blinking the default behaviour
 - [ ] add `random` to options to allow any string to be typed
 - [ ] pause typing in the middle of a string whenever a `^` character is seen
 
@@ -50,8 +50,8 @@ where `options` can be any of:
 ## Features
 - Can **type** and **delete** text
 - Supports constant **looping** between text
-- Cursor customization with custom-style
-- Smart **noretype** function that finds common parts of consecutive strings
+- Cursor **blinkin** and customization with custom-style
+- Smart **noretype** to keep common parts of consecutive strings
 - Style it however you want for cool effects!
 
 ## Contribute

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Check out the [demo and full documentation](https://www.webcomponents.org/elemen
 
 ## TODO
 - [x] make looping & blinking the default behaviour
+- [ ] strings from static html
 - [ ] add `random` to options to allow any string to be typed
 - [ ] pause typing in the middle of a string whenever a `^` character is seen
 - [ ] create demos

--- a/README.md
+++ b/README.md
@@ -22,13 +22,6 @@ Check out the [demo and full documentation](https://www.webcomponents.org/elemen
 ```
 -->
 
-## TODO
-- [x] make looping & blinking the default behaviour
-- [ ] strings from static html
-- [ ] add `random` to options to allow any string to be typed
-- [ ] pause typing in the middle of a string whenever a `^` character is seen
-- [ ] create demos
-
 ## Install
 ```bash
 bower install --save sespiros/typed-text
@@ -50,6 +43,25 @@ where `options` can be any of:
 * `noretype`: only backspaces to erase the part of the string that is different
 * `noloop`: stops typing after the last string
 * `noblink`: stops the cursor from blinking
+
+### Strings
+The typed-text strings can be set in one of two ways:
+* Using the strings property:
+```html
+<typed-text strings='["Hello world", "Another sentence"]'></typed-text>
+```
+* Writing directly into the HTML element:
+```html
+  <typed-text>
+    <p>Here is the first sentence.</p> 
+    <p>Here is another one!</p>
+  </typed-text>
+```
+
+### Cursor
+```html
+<typed-text cursor="|"></typed-text>
+```
 
 ## Features
 - Can **type** and **delete** text

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Polymer 2.0 element that simulates typing similar to [typed.js](https://github.com/mattboldt/typed.js/) for jQuery.
 
-Check out the [demo and full documentation](https://beta.webcomponents.org/element/sespiros/typed-text)
+Check out the [demo and full documentation](https://www.webcomponents.org/element/sespiros/typed-text)
 
 <!--
 ```
@@ -22,27 +22,36 @@ Check out the [demo and full documentation](https://beta.webcomponents.org/eleme
 ```
 -->
 
-## Setup
-Install with bower or [download the zip](https://github.com/sespiros/typed-text/archive/v1.0.0.zip)
+## TODO
+- [ ] make looping the default behaviour
+- [ ] add `random` to options to allow any string to be typed
+- [ ] pause typing in the middle of a string whenever a `^` character is seen
+
+## Install
 ```bash
 bower install --save sespiros/typed-text
 ```
-Import it in your code
+Install with bower or [download the zip](https://github.com/sespiros/typed-text/archive/v1.0.0.zip)
+
+## Import
 ```html
-<!-- for relative paths -->
-<link rel="import"href="../bower_components/typed-text/typed-text.html">
+<link rel="import" href="/bower_components/typed-text/typed-text.html">
 ```
 
 ## Usage
 ```html
-<typed-text></typed-text>
+<typed-text options></typed-text>
 ```
+where `options` can be any of:
+* `strings`: an array of strings to be typed one after the other i.e. `["Hello world!", "typed-text is awesome"]`
+* `cursor`: specify a cursor string. `|` by default
+* `noretype`: only backspaces to erase the part of the string that is different
 
 ## Features
 - Can **type** and **delete** text
 - Supports constant **looping** between text
 - Cursor customization with custom-style
-- Smart **noretype** function that finds common parts of consecutive strings as shown in the [demo](http://sespiros.github.io/typed-text/)
+- Smart **noretype** function that finds common parts of consecutive strings
 - Style it however you want for cool effects!
 
 ## Contribute

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Check out the [demo and full documentation](https://www.webcomponents.org/elemen
 - [x] make looping & blinking the default behaviour
 - [ ] add `random` to options to allow any string to be typed
 - [ ] pause typing in the middle of a string whenever a `^` character is seen
+- [ ] create demos
 
 ## Install
 ```bash
@@ -46,11 +47,13 @@ where `options` can be any of:
 * `strings`: an array of strings to be typed one after the other i.e. `["Hello world!", "typed-text is awesome"]`
 * `cursor`: specify a cursor string. `|` by default
 * `noretype`: only backspaces to erase the part of the string that is different
+* `noloop`: stops typing after the last string
+* `noblink`: stops the cursor from blinking
 
 ## Features
 - Can **type** and **delete** text
 - Supports constant **looping** between text
-- Cursor **blinkin** and customization with custom-style
+- Cursor **blinking** and customization with custom-style
 - Smart **noretype** to keep common parts of consecutive strings
 - Style it however you want for cool effects!
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -17,11 +17,9 @@
     <p>An example of <code>&lt;typed-text&gt;</code>:</p>
     <!-- block cursor -->
     <!-- <typed-text cursor="▍" noretype loop strings='[ -->
-    <typed-text noretype loop blink strings='[
-      "Polymer is awesome",
-      "Polymer is easy",
-      "Polymer rocks!",
-      "<typed-text> element rocks too!"
-    ]'></typed-text>
+    <typed-text noretype>
+        Strings can be placed directly inside the element!
+        <p>They can even be <span>be nested!</span></p>
+  </typed-text>
   </body>
 </html>

--- a/typed-text.html
+++ b/typed-text.html
@@ -73,7 +73,7 @@ An element that simulates typing
         }
       }
     </style>
-    <div>{{typed}}<span class$="cursor [[_isBlinking(blink)]]">{{cursor}}</span></div>
+    <div>{{typed}}<span class$="cursor [[_isBlinking(noblink)]]">{{cursor}}</span></div>
   </template>
 
   <script>
@@ -93,15 +93,8 @@ An element that simulates typing
         },
 
         // Loops between the strings
-        loop: {
-          type: Boolean,
-          value: true
-        },
-
-        blink: {
-          type: Boolean,
-          value: true
-        },
+        noloop: Boolean,
+        noblink: Boolean,
 
         // Time to wait between typed text
         wait: {
@@ -171,7 +164,7 @@ An element that simulates typing
           if(this._index <= this.strings[this._arrayIndex].length){
             this.async(this._typing, this.speed);
           } else {
-            if(this.loop || (this._arrayIndex != this.strings.length - 1)) {
+            if(!this.noloop || (this._arrayIndex != this.strings.length - 1)) {
               this.async(this._deleting, this.wait);
             }
           }
@@ -203,7 +196,7 @@ An element that simulates typing
       },
 
       _isBlinking: function() {
-        return this.blink && 'blink';
+        return !this.noblink && 'blink';
       }
     });
 

--- a/typed-text.html
+++ b/typed-text.html
@@ -94,7 +94,11 @@ An element that simulates typing
 
         // Loops between the strings
         noloop: Boolean,
-        noblink: Boolean,
+
+        noblink: {
+          type: Boolean,
+          value: false
+        },
 
         // Time to wait between typed text
         wait: {

--- a/typed-text.html
+++ b/typed-text.html
@@ -93,9 +93,15 @@ An element that simulates typing
         },
 
         // Loops between the strings
-        loop: Boolean,
+        loop: {
+          type: Boolean,
+          value: true
+        },
 
-        blink: Boolean,
+        blink: {
+          type: Boolean,
+          value: true
+        },
 
         // Time to wait between typed text
         wait: {

--- a/typed-text.html
+++ b/typed-text.html
@@ -156,7 +156,14 @@ An element that simulates typing
       // Element Lifecycle
       ready: function() {
         this._calculateSubIndex(this._arrayIndex);
+        this.async(this.setStrings, 500);
         this.async(this._typing, 500);
+      },
+
+      // Get strings from typed-text element
+      _setStrings: function() {
+        this.strings = strip(this.innerHTML).replace(/ +(?= )/g, '').split("\n ");
+        this.strings.pop(); 
       },
 
       // Element Behavior

--- a/typed-text.html
+++ b/typed-text.html
@@ -78,6 +78,11 @@ An element that simulates typing
 
   <script>
 
+    function strip(html){
+      var doc = new DOMParser().parseFromString(html, 'text/html');
+      return doc.body.textContent;
+    }
+
     Polymer({
 
       is: 'typed-text',
@@ -88,7 +93,9 @@ An element that simulates typing
         strings: {
           type: Array,
           value: function() {
-            return ['typed-text is awesome', 'it supports deleting!'];
+            // Uncomment below if you want the element strings property to override the inner HTML text
+            // return ['typed-text is awesome', 'it supports deleting!']; 
+            return [];
           }
         },
 
@@ -155,15 +162,19 @@ An element that simulates typing
 
       // Element Lifecycle
       ready: function() {
-        this._calculateSubIndex(this._arrayIndex);
-        this.async(this.setStrings, 500);
+        // Get strings from HTML if the `strings` array hasn't been set
+        if (this.strings.length == 0){
+          this.async(this._setStrings, 500);
+        }
         this.async(this._typing, 500);
       },
 
-      // Get strings from typed-text element
+      // Get strings from HTML
       _setStrings: function() {
         this.strings = strip(this.innerHTML).replace(/ +(?= )/g, '').split("\n ");
-        this.strings.pop(); 
+        this.strings = this.strings.filter(function(str) {
+          return /\S/.test(str);
+        }); 
       },
 
       // Element Behavior


### PR DESCRIPTION
## Updated feature behaviour
There are a couple of features that typed.js has enabled by default that seem convenient to activate by default rather than requiring properties to be set.
* the cursor *blinks* by default. `noblink` must be set to disable this
* the sentences *loop* by default. `noloop` must be set to disable this

## Writing strings in HTML
Rather than requiring users to create an `strings` array, it might be more convenient to allow text to be typed directly into the element and parsed. Sentences can be separated by placing them in different divs:
```html
<typed-text>
  Here is a string!
  <p>Here is another string</p>
  <p>It even supports<span>nested strings!</span></p>
</typed-text>
```